### PR TITLE
Fixes for GCC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ list(APPEND srcs
   "${dir}/identifiers.f90"
   "${dir}/intmodes.f"
   "${dir}/io.f"
-  "${dir}/iomod.f90"
+  "${dir}/iomod.F90"
   "${dir}/ligands.f90"
   "${dir}/ls_rmsd.f90"
   "${dir}/marqfit.f"

--- a/src/Makefile
+++ b/src/Makefile
@@ -168,7 +168,7 @@ fortran.o : $(CUDA)/src/fortran.c
 # aus *.F mache ein *.f
 %.f: %.F
 	@echo "making $@ from $<"
-	$(CC) $(PREFLAG) $(PREOPTS) $< -o $@
+	$(FC) $(PREFLAG) $(PREOPTS) $< -o $@
 
 # aus *.f mache ein *.o
 $(OBJDIR)/%.o: %.f
@@ -176,6 +176,10 @@ $(OBJDIR)/%.o: %.f
 	$(FC) $(FFLAGS) $(INC) -c $< -o $@
 
 $(OBJDIR)/%.o: %.f90
+	@echo "making $@ from $<"
+	$(FC) $(FFLAGS) -c $< -o $@
+
+$(OBJDIR)/%.o: %.F90
 	@echo "making $@ from $<"
 	$(FC) $(FFLAGS) -c $< -o $@
 

--- a/src/ccegen.f90
+++ b/src/ccegen.f90
@@ -891,7 +891,7 @@ end function eucdist
 ! 
 !======================================================================!
 subroutine kmeans(nclust,npc,mm,centroid,pcvec,ndist,dist,member)
-    use iso_fortran_env, wp => real64, idp => int64, sp => real32, ap => real32
+    use iso_fortran_env, wp => real64, idp => int64, sp => real32, ap => real64
     implicit none
     integer,intent(in) :: nclust  ! number of required centroids
     integer,intent(in) :: npc,mm

--- a/src/confcross.f90
+++ b/src/confcross.f90
@@ -46,10 +46,11 @@ subroutine confcross(env,maxgen,kk)
       parameter (autokcal=627.509541d0)
       parameter (pi =  3.14159265358979D0)
 
-      integer :: i,j,k,l,m,nall,n,lin,ig,ng,m1,ierr,nmax,nl,kl,kk
+      integer :: i,j,k,l,m,nall,n,ig,ng,m1,ierr,nmax,nl,kl,kk
       integer :: maxgen,r,n2,nk,ident,nmaxmax,ii
       integer :: io,ich
       integer TID, OMP_GET_NUM_THREADS, OMP_GET_THREAD_NUM, nproc
+      integer, external :: lin
 
       character(len=512) :: thispath
       character(len=80) :: atmp,btmp,ctmp,fname,oname

--- a/src/confcross.f90
+++ b/src/confcross.f90
@@ -366,7 +366,6 @@ subroutine confcross(env,maxgen,kk)
 !---- change back to working directory
       call chdir(trim(thispath))
 
-!      stop
 666   continue
 
       deallocate(ind)

--- a/src/confopt.f90
+++ b/src/confopt.f90
@@ -39,7 +39,6 @@ subroutine confopt(env,xyz,TMPCONF,confcross)
       implicit none
  
       type(systemdata) :: env
-      !type(options)    :: opt
 
       character(len=*),intent(in)  :: xyz   !file base name
       integer,intent(in) :: TMPCONF  !number of structures to be optimized
@@ -112,7 +111,6 @@ subroutine confopt(env,xyz,TMPCONF,confcross)
          goto 667
       endif
  
-      write(*,*) trim(jobcall)
       !-- Do the optimizations (parallel system calls) 
       call opt_OMP_loop(TMPCONF,'TMPCONF',jobcall,niceprint)
 

--- a/src/confopt.f90
+++ b/src/confopt.f90
@@ -112,6 +112,7 @@ subroutine confopt(env,xyz,TMPCONF,confcross)
          goto 667
       endif
  
+      write(*,*) trim(jobcall)
       !-- Do the optimizations (parallel system calls) 
       call opt_OMP_loop(TMPCONF,'TMPCONF',jobcall,niceprint)
 
@@ -223,9 +224,6 @@ subroutine opt_OMP_loop(TMPCONF,base,jobcall,niceprint)
       character(len=512) :: str,thispath,tmppath,optpath
 
 
-!----- quick settings
-      bdir = trim(adjustl(base))
-
       !niceprint=env%niceprint
       if(niceprint)then
         call printemptybar()
@@ -239,8 +237,9 @@ subroutine opt_OMP_loop(TMPCONF,base,jobcall,niceprint)
          vz=i
       !$omp task firstprivate( vz ) private( tmppath,io )
          call initsignal()
-         write(tmppath,'(a,i0)')bdir,vz
-         !call system('cd '//trim(tmppath)//' && '//trim(jobcall))
+         write(tmppath,'(a,i0)')trim(base),vz
+         !write(str,'("cd ",a," && ",a)')trim(tmppath),trim(jobcall)
+         !write(*,*) trim(str)
          call execute_command_line('cd '//trim(tmppath)//' && '//trim(jobcall), exitstat=io)
       !$omp critical
         k=k+1

--- a/src/confparse.f90
+++ b/src/confparse.f90
@@ -65,7 +65,7 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
        do i=1,nra
              if( any( (/'--GUI','--gui'/)==trim(arg(i)))) gui =.true.
              if( '-niceprint'==trim(arg(i)) ) env%niceprint=.true.
-             if( any( (/'-version','--version'/)==trim(arg(i))))then
+             if( any( (/character(9)::'-version','--version'/)==trim(arg(i))))then
                  call confscript_head()
                  stop
              endif
@@ -85,10 +85,10 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
 
 !--- check if help is requested or citations shall be diplayed
       do i=1,nra
-            if( any( (/'-h','-H','--h','--H','--help'/)==trim(arg(i))))then
+            if( any( (/character(6)::'-h','-H','--h','--H','--help'/)==trim(arg(i))))then
                call confscript_help()
             endif
-            if( any( (/'-cite','--cite','--citation'/)==trim(arg(i))))then
+            if( any( (/character(10)::'-cite','--cite','--citation'/)==trim(arg(i))))then
                call crestcite()
             endif
       enddo

--- a/src/confscript2_misc.f90
+++ b/src/confscript2_misc.f90
@@ -741,37 +741,37 @@ subroutine  setMDrun2(fname,hmass,mdtime,mdtemp,mdstep,shake,mddumpxyz, &
     enddo
     !--- then write the MD settings 
     write(ich,'(a)') '$md'
-         if(hmass.gt.0)then      !set H-atom mass
+         if(hmass>0.0_wp)then      !set H-atom mass
             write(ich,'(2x,a,i0)') 'hmass=',nint(hmass)
          endif
-         if(mdtime.gt.0.0d0)then     !set MD simulation time in ps
+         if(mdtime>0.0_wp)then     !set MD simulation time in ps
             write(ich,'(2x,a,f10.2)') 'time=',mdtime
          endif
-         if(mdtemp.gt.0)then     !set MD Temperature
+         if(mdtemp>0.0_wp)then     !set MD Temperature
             write(ich,'(2x,a,f10.2)') 'temp=',mdtemp
          endif
          if(mdstep.gt.0)then     !set MD timestep in fs
             write(ich,'(2x,a,f10.2)') 'step=',mdstep
          endif
-         if(shake.ge.0)then     !set MD shake mode
+         if(shake>=0)then     !set MD shake mode
             write(ich,'(2x,a,i0)')'shake=',shake
          endif
          !the order of setting mddump and mddumpxyz is important!!!
-         if(mddumpxyz.gt.0)then    ! Frequency of structure dump into xtb.trj in fs
+         if(mddumpxyz>0)then    ! Frequency of structure dump into xtb.trj in fs
             write(ich,'(2x,a,i0)')'dump=',mddumpxyz
          endif
-         if(mdskip.ge.0)then    !skipping optimizations in -mdopt
+         if(mdskip>=0)then    !skipping optimizations in -mdopt
              write(ich,'(2x,a,i0)')'skip=',mdskip
          endif
-         if(nvt.ge.0)then      ! NVT ensemble
-           if(nvt.eq.0)then
+         if(nvt>=0)then      ! NVT ensemble
+           if(nvt==0)then
              write(ich,'(2x,a)')'nvt=false'
            else
              write(ich,'(2x,a)')'nvt=true'
            endif
          endif
          !the order of setting mddump and mddumpxyz is important!!!
-         if(mddump.gt.0)then     ! Vbias dump for metadyn in fs                       
+         if(mddump>0)then     ! Vbias dump for metadyn in fs                       
             write(ich,'(a)')'$set'
             write(ich,'(2x,a,2x,i0)')'mddump',mddump
          endif
@@ -786,6 +786,7 @@ subroutine  setMDrun2(fname,hmass,mdtime,mdtemp,mdstep,shake,mddumpxyz, &
     endif
     call write_cts_rcontrol(ich,cts)
     write(ich,'(a)') '$end'
+    close(ich)
     return
 end subroutine setMDrun2
 

--- a/src/confscript2_misc.f90
+++ b/src/confscript2_misc.f90
@@ -332,6 +332,7 @@ subroutine MetaMD_para_OMP(env)
       character(len=512) :: jobcall
       character(len=80)  :: fname,pipe,solv,atmp,btmp
       integer :: dum,io
+      logical :: ex
 
       if(env%autothreads)then
          dum = env%nmetadyn
@@ -372,7 +373,7 @@ subroutine MetaMD_para_OMP(env)
       do i=1,env%nmetadyn
          call initsignal()
          vz=i
-       !$omp task firstprivate( vz ) private( tmppath,io )
+       !$omp task firstprivate( vz ) private( tmppath,io,ex )
          call initsignal()
        !$omp critical
              write(*,'(a,i4,a)') 'Starting Meta-MD',vz,' with the settings:'
@@ -385,8 +386,8 @@ subroutine MetaMD_para_OMP(env)
        !$omp end critical
          write(tmppath,'(a,i0)')'METADYN',vz
          call execute_command_line('cd '//trim(tmppath)//' && '//trim(jobcall), exitstat=io)
-         inquire(file=trim(tmppath)//'/'//'xtb.trj',exist=io)
-         if(.not.io)then
+         inquire(file=trim(tmppath)//'/'//'xtb.trj',exist=ex)
+         if(.not.ex .or. io.ne.0)then
          write(*,'(a,i0,a)')'*Warning: Meta-MTD ',vz,' seemingly failed (no xtb.trj)*'
          call system('cp -r '//trim(tmppath)//' FAILED-MTD')
          else
@@ -976,7 +977,7 @@ subroutine collect_trj(base,whichfile)
       i=1
       do
         write(dir,'(a,i0)')trim(base),i
-        inquire(directory=trim(dir),exist=ex)
+        ex = directory_exist(trim(dir))
         if(.not.ex)then
           exit
         else
@@ -1001,7 +1002,7 @@ subroutine collect_trj_skipfirst(base,whichfile)
       i=1
       do
         write(dir,'(a,i0)')trim(base),i
-        inquire(directory=trim(dir),exist=ex)
+        ex = directory_exist(trim(dir))
         if(.not.ex)then
           exit
         else

--- a/src/cregen.f90
+++ b/src/cregen.f90
@@ -28,6 +28,7 @@ subroutine cregen2(env)
       use ls_rmsd
       use iomod
       use strucrd, only: rdnat,rdcoord,wrc0,i2e,e2i
+   !$ use omp_lib
       implicit none
       type(systemdata) :: env    ! MAIN STORAGE OS SYSTEM DATA
       !type(options) :: opt       ! MAIN STORAGE OF BOOLEAN SETTINGS
@@ -55,39 +56,43 @@ subroutine cregen2(env)
       real(wp) :: autokcal,beta,eav,A,T,rthr,s,g
       real(wp) :: ss,ethr,de,dr,bthr,aa
       real(wp) :: elow,psum,ewin,pthr,eref,athr,r,dsum,dav
-      real(wp) :: rotdiff,dum,shortest_distance,distcma,esort
+      real(wp) :: dum,distcma,esort
       real(wp) :: rij(3),ri,rj,cnorm,erj
       !real*8 :: gdum(3,3),Udum(3,3),xdum(3), ydum(3)  ! rmsd dummy stuff
+      real(wp), external :: rotdiff,shortest_distance
 
       parameter (autokcal=627.509541d0)
 
-      integer :: i,j,k,l,m,nall,n,lin,ig,ng,nall2,norig
+      integer :: i,j,k,l,m,nall,n,ig,ng,nall2,norig
       integer :: m1,m2,s1,s2,maxg,current,mm,mmm,ndoub
       integer :: molcount0,j1,iat,k2,molcount,m1end,imax
       integer :: kk,memb,irr,ir,nr,jj,nall_old,iig
-      integer :: TID, OMP_GET_NUM_THREADS, OMP_GET_THREAD_NUM, nproc
-      integer :: ich,ich2,io,ich3
-      integer*8 :: lina,linr
+      integer :: TID, nproc
+      integer :: ich,ich2,io,ich3,rednat
+      integer, external :: lin
+      integer*8, external :: lina,linr
       integer(idp) :: klong
       integer(idp),allocatable :: rmatmap1(:)
-      integer,allocatable :: rmatmap2(:)
+      integer,allocatable :: rmatmap2(:),includeRMSD(:)
 
       character(len=80) :: atmp,btmp,ctmp,oname,fname,cname
       character(len=3) :: a3            
       character(len=512) :: outfile
 
-      logical :: debug,heavy,equalrot,l1,l2,l3,ex,newfile,anal,rmsdchk
-      logical :: exchok,distcheck,fail,equalrot2
-      logical :: substruc,equalrotall
+      logical :: debug,heavy,l1,l2,l3,ex,newfile,anal,rmsdchk
+      logical :: exchok,fail,equalrot2
+      logical :: substruc
       logical :: ttag
+      logical, external :: distcheck,equalrot,equalrotall
 
       settingNames: associate( crestver => env%crestver, confgo => env%confgo, &
       &             methautocorr => env%methautocorr, printscoords => env%printscoords,  &
       &             ensemblename => env%ensemblename, compareens => env%compareens,      &
       &             elowest => env%elowest, ENSO => env%ENSO, subRMSD => env%subRMSD,    &
       &             trackorigin => env%trackorigin, autothreads => env%autothreads,      &
-      &             omp => env%omp, MAXRUN => env%MAXRUN, threads => env%threads,        &
-      &             rednat => env%rednat, includeRMSD => env%includeRMSD)
+      &             omp => env%omp, MAXRUN => env%MAXRUN, threads => env%threads)
+      rednat = env%rednat
+      includeRMSD = env%includeRMSD
 
       thresholdNames: associate( cgf => env%cgf, thresholds => env%thresholds)
 

--- a/src/crest_main.f90
+++ b/src/crest_main.f90
@@ -179,7 +179,7 @@ program CREST
         call propquit(tim)
   !---- extended tautomerization
        case( p_tautomerize2 )
-        call tautomerize_ext(env,env%ensemblename,env,tim)
+        call tautomerize_ext(env%ensemblename,env,tim)
         call propquit(tim)
   !---- stereoisomerization
        case( p_isomerize )

--- a/src/ensemblecomp.f90
+++ b/src/ensemblecomp.f90
@@ -73,8 +73,8 @@ subroutine compare_ensembles(env)
          real(wp),parameter :: autokcal = 627.509541d0
 
          associate( ensemblename => env%ensemblename, ensemblename2 => env%ensemblename2, &
-         & thresholds => env%thresholds, cgf => env%cgf, maxcompare => env%maxcompare,    &
-         & nat => env%nat)
+         & thresholds => env%thresholds, cgf => env%cgf, maxcompare => env%maxcompare)
+         nat = env%nat
 
 !----
       call compens_cleanup()

--- a/src/entropic.f90
+++ b/src/entropic.f90
@@ -1210,7 +1210,7 @@ subroutine atmsTobool(n,atms,bool)
      implicit none
      integer :: n
      integer :: atms(n)
-     integer :: bool(n)
+     logical :: bool(n)
      integer :: i
      do i=1,n
        if(atms(i).ne.0)then
@@ -1339,6 +1339,7 @@ end subroutine analsym
 subroutine analsym_geo(grp,nat,xyz,at,fac,pr,sfsm)
       use iso_fortran_env, wp => real64
       use zdata
+      implicit none
       type(zequal) :: grp
       real(wp),intent(out) :: fac
       logical :: pr
@@ -1348,13 +1349,13 @@ subroutine analsym_geo(grp,nat,xyz,at,fac,pr,sfsm)
       integer :: i,io
       character(len=4) :: sfsym
       character(len=4),intent(out) :: sfsm
-      real(wp) :: symfactor
+      real(wp),external :: symfactor
       real(wp),parameter :: desy = 0.1_wp
       integer,parameter  :: maxat = 200
       fac = 1.0_wp
       call getsymmetry2(pr,6,nat,at,xyz, desy, maxat, sfsym)
 
-      fac = 1.0_wp / symfactor(grps,sfsym)
+      fac = 1.0_wp / symfactor(grp,sfsym)
       sfsm=sfsym(1:3)
       return
 end subroutine analsym_geo

--- a/src/io.f
+++ b/src/io.f
@@ -97,6 +97,7 @@
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
       subroutine getname_dir(base,fname)
+      use iomod, only : directory_exist
       character(len=*) :: base,fname
       integer :: i
       logical :: ex
@@ -106,7 +107,8 @@
       do
         i=i+1
         write(dir,'(a,i0)')trim(base),i
-        inquire(directory=dir,exist=ex)
+        ! Inquire is not consitent across compilers
+        ex = directory_exist(dir)
         if(.not.ex)then
           fname=trim(dir) 
           exit

--- a/src/io.f
+++ b/src/io.f
@@ -276,18 +276,17 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       character(len=*) :: to
       integer :: i,j,k,nat
       character(len=1024) :: str
-
       open(unit=666,file=to)
       open(unit=777,file=from)
-
       do
         read(666,*,iostat=io)
-        if(io<0)exit
+        if(io<0)then
+          backspace(666)  
+          exit
+        endif
       enddo
-     
       read(777,*)nat
       write(666,*)nat
-
       do i=1,nat+1
         read(777,'(a)',iostat=io)str
         if(io<0)exit
@@ -312,7 +311,10 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       open(newunit=och,file=from)
       do
         read(ich,*,iostat=io)
-        if(io<0)exit
+        if(io<0)then
+           backspace(ich) 
+           exit
+        endif
       enddo
       !---first structure is read, but not copied 
       read(och,'(a)',iostat=io)str

--- a/src/iomod.F90
+++ b/src/iomod.F90
@@ -243,12 +243,18 @@ subroutine appendto(from,to)
       open(newunit=och,file=from)
       do
         read(ich,*,iostat=io)
-        if(io<0)exit
+        if(io<0)then
+            backspace(ich)
+            exit
+        endif
       enddo
       do
         read(och,'(a)',iostat=io)str
-        if(io<0)exit
-        write(ich,'(a)')trim(str)
+        if(io<0)then
+            exit
+        else
+            write(ich,'(a)')trim(str)
+        endif
       enddo
       close(och)
       close(ich)

--- a/src/iomod.F90
+++ b/src/iomod.F90
@@ -612,5 +612,20 @@ function filechecker(fin,fout) result(have)
     return
 end function filechecker
 
+! Checking directories with Fortran's inquire is not handled by the standard.
+! The interpretation whether or not to report a directory as file is compiler
+! specific and therefore always an extension to the Fortran standard.
+function directory_exist(file) result(exist)
+    character(len=*), intent(in) :: file
+    logical :: exist
+#ifdef __INTEL_COMPILER
+    ! Intel provides the directory extension to inquire to handle this case
+    inquire(directory=file, exist=exist)
+#else
+    ! GCC handles directories as files, to make sure we get a directory and
+    ! not a file append a path separator and the current dir
+    inquire(file=trim(file)//"/.", exist=exist)
+#endif
+end function directory_exist
 
 end module iomod

--- a/src/ligands.f90
+++ b/src/ligands.f90
@@ -93,6 +93,15 @@ subroutine exchangeligands(infile,infile2,centeratom,ligandnr)
     real(wp),allocatable :: xyz(:,:)
     integer,allocatable :: at(:)
     character(len=128) :: atmp,btmp
+    interface
+        subroutine matchligands(mol1,mol2,metal)
+            import :: coord, wp
+            implicit none
+            type(coord) :: mol1 !reference ligand
+            type(coord) :: mol2 !new ligand
+            real(wp),optional :: metal(3) !coordinates of the metal center
+        end subroutine matchligands
+    end interface
     real(wp) :: refdist !distance of the old ligand
     type(coord) :: oldligand
     type(coord) :: newligand

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,7 +48,7 @@ srcs += files(
   'identifiers.f90',
   'intmodes.f',
   'io.f',
-  'iomod.f90',
+  'iomod.F90',
   'ligands.f90',
   'ls_rmsd.f90',
   'marqfit.f',

--- a/src/msreact.f90
+++ b/src/msreact.f90
@@ -36,6 +36,16 @@ subroutine msreact_handler(env,tim)
     type(msobj) :: mso  !a new msreact object
     type(coord) :: struc
 
+    interface
+        subroutine msreact_topowrap(mol,pair,paths,wboname)
+            import :: msmol
+            implicit none
+            type(msmol) :: mol
+            integer :: pair(mol%nat*(mol%nat+1)/2)
+            integer :: paths(mol%nat*(mol%nat+1)/2,mol%nat)
+            character(len=*),optional :: wboname
+        end subroutine msreact_topowrap
+    end interface
     integer :: nat
     integer,allocatable :: pair(:)
     integer,allocatable :: paths(:,:)

--- a/src/normmd.f90
+++ b/src/normmd.f90
@@ -465,7 +465,7 @@ subroutine entropyMD_para_OMP(env)
 !$omp single
       do i=1,tot
          vz=i
-       !$omp task firstprivate( vz ) private( tmppath,io )
+       !$omp task firstprivate( vz ) private( tmppath,io,ex )
          call initsignal()
        !$omp critical
              write(*,'(a,i4,a)') 'Starting MTD',vz,' with the settings:'
@@ -478,8 +478,8 @@ subroutine entropyMD_para_OMP(env)
        !$omp end critical
          write(tmppath,'(a,i0)')'STATICMTD',vz
          call execute_command_line('cd '//trim(tmppath)//' && '//trim(jobcall), exitstat=io)
-         inquire(file=trim(tmppath)//'/'//'xtb.trj',exist=io)
-         if(.not.io)then
+         inquire(file=trim(tmppath)//'/'//'xtb.trj',exist=ex)
+         if(.not.ex .or. io.ne.0)then
          write(*,'(a,i0,a)')'*Warning: static MTD ',vz,' seemingly failed (no xtb.trj)*'
          call system('cp -r '//trim(tmppath)//' FAILEDMTD')
          else

--- a/src/optinplace.f90
+++ b/src/optinplace.f90
@@ -43,6 +43,7 @@ subroutine MDopt_para_inplace(env,ensnam,multilev)
 
          real(wp) :: lev
 
+         integer :: nat
          real(wp),allocatable :: eread(:)
          real(wp),allocatable :: xyz(:,:,:)
          integer,allocatable  :: at(:)
@@ -61,7 +62,7 @@ subroutine MDopt_para_inplace(env,ensnam,multilev)
 
          logical :: verbose,l1
        
-         associate( nat => env%nat )
+         nat = env%nat
 
 !---- get current path
          call getcwd(thispath)
@@ -281,5 +282,4 @@ subroutine MDopt_para_inplace(env,ensnam,multilev)
 !---- go back to original directory
       call chdir(thispath)
 
-      end associate
 end subroutine MDopt_para_inplace

--- a/src/pka.f90
+++ b/src/pka.f90
@@ -160,7 +160,16 @@ subroutine pkaquick(env,tim)
       real(wp) :: GA,GB,dG
       real(wp) :: eatb,gsa,grrhoa,ebtb,gsb,grrhob,dE
       real(wp) :: pKa,dum,pkaref
-      real(wp) :: pKaCFER !this is a function
+      interface
+          function pKaCFER(dG,c1,c2,c3,c4,T) result(pka)
+              import :: wp
+              implicit none
+              real(wp) :: dG         !in Eh
+              real(wp),optional :: T !in K
+              real(wp) :: pka
+              real(wp) :: c1,c2,c3,c4
+          end function pKaCFER
+      end interface
       real(wp) :: c0,c1,c2,c3,c4
       integer :: i,j,k,l,h,ich,io
       integer :: refnat,refchrg
@@ -375,12 +384,13 @@ contains
        character(len=*) :: fname
        character(len=1028) :: jobcall
        integer :: io
+       logical :: ex
        call env%wrtCHRG('')
        write(jobcall,'(a,1x,a,1x,a,'' --ceasefiles --opt '',a,1x,a,'' >xtb.out'')') &
        &    trim(env%ProgName),trim(fname),trim(env%gfnver),trim(env%solv),' 2>/dev/null'
        call execute_command_line(trim(jobcall), exitstat=io)
-       inquire(file='xtbopt.xyz',exist=io)
-       if(io)then
+       inquire(file='xtbopt.xyz',exist=ex)
+       if(ex)then
            call rename('xtbopt.xyz',fname)
        endif
        call remove('xtbrestart')

--- a/src/propcalc.f90
+++ b/src/propcalc.f90
@@ -65,6 +65,18 @@ subroutine propcalc(iname,imode,env,tim)
       integer :: P
       integer :: fileid,ich
 
+      interface
+          subroutine prop_OMP_loop(env,TMPCONF,jobcall,pop)
+              import :: systemdata, wp
+              implicit none
+
+              type(systemdata) :: env
+              integer :: TMPCONF
+              character(len=1024) :: jobcall
+              real(wp),intent(in),optional :: pop(TMPCONF)
+          end subroutine
+      end interface
+
       character(len=20) :: xname
       character(len=20) :: optl,pipe
       character(len=80) :: solv
@@ -245,7 +257,7 @@ subroutine propcalc(iname,imode,env,tim)
       enddo
       write(*,'(1x,a)') 'done.'
 
-      if(any(mask==.false.))then
+      if(any(mask.eqv..false.))then
          TMPCONF=ii-1
          nall=ii-1
          if(allocated(popul))deallocate(popul)
@@ -310,7 +322,7 @@ subroutine propcalc(iname,imode,env,tim)
   
       write(*,'(1x,a,i0,a)')'Performing calculations for ', &
       & TMPCONF,' structures ...'
-      call sleep(0.5_wp)
+      call sleep(1)
       call tim%start(10,'PROPERTY calc.')
       allocate(dumm(TMPCONF), source=1.0_wp)
       call prop_OMP_loop(env,TMPCONF,jobcall,dumm)  !<------- this is where the "magic" happens

--- a/src/stereoisomers.f90
+++ b/src/stereoisomers.f90
@@ -434,13 +434,14 @@ subroutine cip_sphere(zmol,k,i,s,sphere)
       integer,intent(inout) :: sphere(zmol%nat)
       integer,allocatable :: sphereold(:)
 
-      integer :: j,m,n
+      integer :: j,m,n,dummy
 
       allocate(sphereold(zmol%nat), source=0)
 
       !get the s-th sphere in direction of i
       sphere=0
-      call cip_getsphere(zmol,k,i,1,s,sphere,sphereold)
+      dummy=1
+      call cip_getsphere(zmol,k,i,dummy,s,sphere,sphereold)
 
       !sphere contains the atoms, which we have now to convert to
       !integer atom types:
@@ -658,7 +659,7 @@ subroutine stereoinvert(zmol)
                 zmol%invector(3,i)=j                                  ! <----
                 !--- get the atoms to be rotated in the special polycycle case
                 yloop2: do y=1,xnei
-                    if(checkcounter(y)==.false.)then
+                    if(checkcounter(y).eqv..false.)then
                      allocate(path2(nat), source = 0)
                      k=zmol%zat(i)%ngh(y)
                      l=0
@@ -676,13 +677,13 @@ subroutine stereoinvert(zmol)
                  !--- get the atoms for the rotational axis setup in the polycyle case
                  yloop3: do y=1,xnei
                    if(zmol%invector(1,i).eq.0)then
-                     if(checkcounter(y)==.true.)then
+                     if(checkcounter(y).eqv..true.)then
                         k=zmol%zat(i)%ngh(y)
                         if(k.eq.zmol%invector(3,i)) cycle yloop3
                         zmol%invector(1,i)=k                           ! <----
                      endif
                    else if(zmol%invector(2,i).eq.0)then
-                     if(checkcounter(y)==.true.)then
+                     if(checkcounter(y).eqv..true.)then
                         k=zmol%zat(i)%ngh(y)
                         if(k.eq.zmol%invector(3,i)) cycle yloop3
                         zmol%invector(2,i)=k                           ! <----
@@ -749,7 +750,7 @@ subroutine whichinvert(zmol,i,these,vec)
      integer :: i
 
      integer,intent(out) :: these(2)  !--- the two neighbours which must be inverted
-     integer,intent(out) :: vec(3)    !--- vector of the inversion axis
+     real(wp),intent(out) :: vec(3)   !--- vector of the inversion axis
 
      integer :: sref
      integer :: j,k,l,m

--- a/src/symmetry2.f90
+++ b/src/symmetry2.f90
@@ -39,7 +39,7 @@ Subroutine get_schoenflies(n,iat,xyz,sfsym,paramar)
    End Interface c_interface
 
    !Dummy Arguments
-   Character (Len=*), target :: sfsym
+   Character (Len=*) :: sfsym
    Integer, Intent (In)  :: n
    Integer, Intent (In)  :: iat (n)
    Real(wp), Intent (In) :: xyz (3, n)

--- a/src/trackorigin.f90
+++ b/src/trackorigin.f90
@@ -177,7 +177,7 @@ subroutine set_trj_origins(base,origin)
       i=1
       do
         write(dir,'(a,i0)')trim(base),i
-        inquire(directory=trim(dir),exist=ex)
+        ex = directory_exist(trim(dir))
         if(.not.ex)then
           exit
         else
@@ -206,7 +206,7 @@ subroutine set_trj_timestamps(base,nsplit)
       i=1
       do
         write(dir,'(a,i0)')trim(base),i
-        inquire(directory=trim(dir),exist=ex)
+        ex = directory_exist(trim(dir))
         if(.not.ex)then
           exit
         else

--- a/src/utilities.f
+++ b/src/utilities.f
@@ -38,7 +38,7 @@
           integer :: i,j
           real*8 :: kf
           real*8 :: idum
-          kf = floatk(k)  !for int8 conversion   
+          kf = real(k, 8)
           idum = 1.0 + 8.0*kf
           !idum = sqrt(idum)
           idum = idum ** 0.5

--- a/src/xtbmodef.f90
+++ b/src/xtbmodef.f90
@@ -46,8 +46,10 @@ subroutine xtbmodef(env,s,e,n,u,l,o,x)
       character(len=868) :: str2
       character(len=1024):: jobcall
       character(len=200):: finfile,runfile
+      character(len=:), allocatable :: ProgName, gfnver
 
       logical:: l1,l2,fin,run,modefok,mop,update,ex,clo
+      logical :: niceprint
 
       real(wp) :: percent
       character(len=52) :: bar
@@ -55,9 +57,12 @@ subroutine xtbmodef(env,s,e,n,u,l,o,x)
 
       call getcwd(thispath)  !get current working directory
 
-      associate( ProgName => env%ProgName, gbsa => env%gbsa, solvent => env%solvent,  &
+      associate( gbsa => env%gbsa, solvent => env%solvent,  &
       & fixfile => env%fixfile, constraints => env%constraints, optlev => env%optlev, &
-      & niceprint => env%niceprint, gfnver => env%gfnver, trackorigin => env%trackorigin)
+      & trackorigin => env%trackorigin)
+      niceprint = env%niceprint
+      gfnver = env%gfnver
+      ProgName = env%ProgName
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/zdata.f90
+++ b/src/zdata.f90
@@ -85,8 +85,8 @@ module zdata
       integer,allocatable :: rlist(:)
 
       contains
-         procedure deallocate => deallocate_zring  !deallocate (if allocated)
-         procedure print => print_zring !print to screen
+         procedure :: deallocate => deallocate_zring  !deallocate (if allocated)
+         procedure :: print => print_zring !print to screen
    end type zring
 
 !==========================================================================================================!
@@ -96,10 +96,10 @@ module zdata
       integer :: nm !# of members in group
       integer,allocatable :: mem(:)
       contains
-         procedure allocate => allocate_zgrp
-         procedure deallocate => deallocate_zgrp
-         procedure append => append_zgrp
-         procedure prgrp => print_zgrp
+         procedure :: allocate => allocate_zgrp
+         procedure :: deallocate => deallocate_zgrp
+         procedure :: append => append_zgrp
+         procedure :: prgrp => print_zgrp
    end type zgrp
    !equivalencies-class. contains information about equivalent nuclei
    type :: zequal
@@ -111,10 +111,10 @@ module zdata
       type(zgrp),allocatable :: grp(:) !all groups (dimension <= nat)
 
       contains
-         procedure allocate => allocate_zequal !allocate nat, ord(:) and grp(:)
-         procedure member => is_x_member       !check if atom x is member of any group
-         procedure prsum => prsummary_zequal   !print a summary of all the groups
-         procedure geteng => zequal_geteng     !count number of groups with more than 1 member
+         procedure :: allocate => allocate_zequal !allocate nat, ord(:) and grp(:)
+         procedure :: member => is_x_member       !check if atom x is member of any group
+         procedure :: prsum => prsummary_zequal   !print a summary of all the groups
+         procedure :: geteng => zequal_geteng     !count number of groups with more than 1 member
 
    end type zequal
 
@@ -197,8 +197,8 @@ module zdata
 
    !--- procedures to be used with the zensemble
       contains
-        procedure allocate =>  allocate_zensemble
-        procedure deallocate => deallocate_zensemble
+        procedure :: allocate =>  allocate_zensemble
+        procedure :: deallocate => deallocate_zensemble
 
    end type zensemble
 

--- a/src/ztopology.f90
+++ b/src/ztopology.f90
@@ -50,6 +50,18 @@ subroutine simpletopo_file(fname,zmol,verbose,wbofile)
      integer,allocatable :: at(:)
      real(wp),allocatable :: xyz(:,:)
      logical :: ex
+     interface
+         subroutine simpletopo(n,at,xyz,zmol,verbose,wbofile)
+             import :: zmolecule, wp
+             implicit none
+             type(zmolecule)  :: zmol       
+             logical          :: verbose
+             integer,intent(in)  :: n
+             integer,intent(in)  :: at(n)
+             real(wp),intent(in) :: xyz(3,n) !in Bohrs
+             character(len=*),intent(in),optional :: wbofile
+         end subroutine simpletopo
+     end interface
 
      call rdnat(fname,n)
      allocate(at(n),xyz(3,n))
@@ -70,12 +82,25 @@ subroutine simpletopo_file(fname,zmol,verbose,wbofile)
 end subroutine simpletopo_file
 
 subroutine simpletopo_mol(mol,zmol,verbose)
+     use iso_fortran_env, wp => real64
      use zdata
      use strucrd
      implicit none
      type(coord)      :: mol    !in 
      type(zmolecule)  :: zmol   !out
      logical          :: verbose
+     interface
+         subroutine simpletopo(n,at,xyz,zmol,verbose,wbofile)
+             import :: zmolecule, wp
+             implicit none
+             type(zmolecule)  :: zmol       
+             logical          :: verbose
+             integer,intent(in)  :: n
+             integer,intent(in)  :: at(n)
+             real(wp),intent(in) :: xyz(3,n) !in Bohrs
+             character(len=*),intent(in),optional :: wbofile
+         end subroutine simpletopo
+     end interface
      call simpletopo(mol%nat,mol%at,mol%xyz,zmol,verbose,'')
      return
 end subroutine simpletopo_mol


### PR DESCRIPTION
- tested with GCC 10.2
- added one subroutine to wrap preprocessor usage
- add explicit interfaces when necessary
- add external attributes to functions
- remove associated variables which are part of OMP pragmas
- use .eqv. instead of .eq. to compare logicals
- fix some type mismatches