### PR TITLE
Add meson support for custom linear algebra backend

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,8 +14,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with crest.  If not, see <https://www.gnu.org/licenses/>.
 
-option('la_backend', type: 'combo', value: 'mkl-static',
-       choices: ['mkl', 'mkl-rt', 'mkl-static', 'openblas', 'netlib', 'custom'],
-       description: 'Linear algebra backend for program.')
-option('custom_libraries', type: 'array', value: [],
-       description: 'libraries to load for custom linear algebra backend')
+option(
+  'la_backend',
+  type: 'combo',
+  value: 'mkl-static',
+  choices: ['mkl', 'mkl-rt', 'mkl-static', 'openblas', 'netlib', 'custom'],
+  description: 'Linear algebra backend for program.',
+)
+option(
+  'custom_libraries',
+  type: 'array',
+  value: [],
+  description: 'libraries to load for custom linear algebra backend',
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,10 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with crest.  If not, see <https://www.gnu.org/licenses/>.
 
-option(
-  'la_backend',
-  type: 'combo',
-  value: 'mkl-static',
-  choices: ['mkl', 'mkl-static', 'openblas', 'netlib'],
-  description: 'Linear algebra backend for program.',
-)
+option('la_backend', type: 'combo', value: 'mkl-static',
+       choices: ['mkl', 'mkl-rt', 'mkl-static', 'openblas', 'netlib', 'custom'],
+       description: 'Linear algebra backend for program.')
+option('custom_libraries', type: 'array', value: [],
+       description: 'libraries to load for custom linear algebra backend')


### PR DESCRIPTION
This is just a copy-paste from xtb, which allows the use of a custom linear algebra backend (needed to build on Fedora).