### PR TITLE
Printout and a default change

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ The `crest` documentation is hosted at [read-the-docs](https://xtb-docs.readthed
 2. S. Grimme, *J. Chem. Theory Comput.*, **2019**, 155, 2847-2862.
   DOI: [10.1021/acs.jctc.9b00143](https://dx.doi.org/10.1021/acs.jctc.9b00143)
 
-3. P. Pracht, S. Grimme, *Chem. Sci.*, **2021**, DOI: [10.1039/d1sc00621e](https://dx.doi.org/10.1039/d1sc00621e)
+3. P. Pracht, S. Grimme, *Chem. Sci.*, **2021**, 12, 6551-6568.
+  DOI: [10.1039/d1sc00621e](https://dx.doi.org/10.1039/d1sc00621e)
 
 ## License
 

--- a/src/classes.f90
+++ b/src/classes.f90
@@ -391,7 +391,7 @@ module crest_data
       integer :: clustlev = 0    ! clustering level
 
     !--- additional structure generation settings
-      logical :: doOHflip = .false.
+      logical :: doOHflip = .true.
       integer :: maxflip = 1000  
 
     !--- external RMSD bias to optimizations

--- a/src/confparse.f90
+++ b/src/confparse.f90
@@ -759,6 +759,8 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
                    env%autozsort=.false.
                 case( '-norotmd' )                         !don't do the regular mds after step 2 in multilevel optimization of V2
                    env%rotamermds=.false.
+                case( '-rotmd')
+                   env%rotamermds=.true.   
                 case( '-tnmd' )                            !temperature for additional normal MDs
                    call readl(arg(i+1),xx,j)
                    env%nmdtemp=xx(1)
@@ -1171,6 +1173,7 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
              case( '-nomlo' )   !turn off multilevel optimization
                 env%multilevelopt = .false.   
              case( '-normmd' )             !set number of normMDs
+                 env%rotamermds=.true.
                if(i+1 .le. nra)then  
                 call readl(arg(i+1),xx,j)
                 env%nrotammds=nint(xx(1))  !how many lowest conformers?

--- a/src/confparse.f90
+++ b/src/confparse.f90
@@ -1105,8 +1105,10 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
                 !call autoBondConstraint('coord',env%forceconst,env%wbofile)
                 ctype = 1
                 bondconst =.true.
+                env%cts%cbonds_global=.true.
                 if( index(argument,'_md').ne.0)then !if the bond constraint shall be present only in the MDs/MTDs
                     env%cts%cbonds_md = .true.
+                    env%cts%cbonds_global=.false.
                 endif
                 if( index(argument,'_ez').ne.0)then !if the bond constraint shall be present only in the MDs/MTDs
                     ctype = 5                 
@@ -1120,8 +1122,10 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
                 !call autoMetalConstraint('coord',env%forceconst,env%wbofile)
                 ctype = 2
                 bondconst =.true.
+                env%cts%cbonds_global=.true.
                 if( index(argument,'_md').ne.0)then
                    env%cts%cbonds_md = .true.
+                   env%cts%cbonds_global=.false.                
                 endif
              case( '-cheavy','-fixheavy','-cheavy_md' )    !constrain all heavy atom bonds
                 ctmp=trim(arg(i+1))
@@ -1132,8 +1136,10 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
                 !call autoHeavyConstraint('coord',env%forceconst,env%wbofile)
                 ctype = 3
                 bondconst =.true.
+                env%cts%cbonds_global=.true.
                 if( index(argument,'_md').ne.0)then
                    env%cts%cbonds_md = .true.
+                   env%cts%cbonds_global=.false.                
                 endif
              case( '-clight','-fixhyd','-clight_md' )  !constraint all X-H bonds
                 ctmp=trim(arg(i+1))
@@ -1144,8 +1150,10 @@ subroutine parseflags(env,arg,nra)  !FOR THE CONFSCRIPT STANDALONE
                 !call autoHydrogenConstraint('coord',env%forceconst,env%wbofile)
                 ctype = 4
                 bondconst =.true.   
+                env%cts%cbonds_global=.true.               
                 if( index(argument,'_md').ne.0)then
                    env%cts%cbonds_md = .true.
+                   env%cts%cbonds_global=.false.                
                 endif
              case( '-cfile','-cinp' )                                 !specify the constrain file
                 ctmp=trim(arg(i+1))

--- a/src/printouts.f90
+++ b/src/printouts.f90
@@ -22,7 +22,7 @@
 !===================================================================================================!
 subroutine confscript_head
       implicit none
-      character(len=40),parameter:: date='Fri 28. May 11:27:32 CEST 2021'
+      character(len=40),parameter:: date='Tue 13. Jul 16:11:14 CEST 2021'
       character(len=10),parameter:: version='2.11'
       logical :: niceprint
       

--- a/src/printouts.f90
+++ b/src/printouts.f90
@@ -22,8 +22,8 @@
 !===================================================================================================!
 subroutine confscript_head
       implicit none
-      character(len=40),parameter:: date='Tue 13. Jul 16:11:14 CEST 2021'
-      character(len=10),parameter:: version='2.11'
+      character(len=40),parameter:: date='Mon 16. Aug 09:59:32 CEST 2021'
+      character(len=10),parameter:: version='2.11.1'
       logical :: niceprint
       
       niceprint=.true.

--- a/src/trialmd.f90
+++ b/src/trialmd.f90
@@ -117,7 +117,7 @@ subroutine trialMD(env)
       !call copysub('.CHRG',trim(dirnam))
       !call copysub('.UHF',trim(dirnam))
       call env%wrtCHRG(trim(dirnam))   
-      call copysub(fixfile,trim(dirnam))
+      call copysub(env%fixfile,trim(dirnam))
       !call copysub(constraints,trim(dirnam))
       if(useqmdff)then
         call copysub('solvent',trim(dirnam))


### PR DESCRIPTION
Default for additional structure creation by HX group rotation was changed.
After MTD block, such structures will be created (if possible).
Can be turned off by `--noflip`